### PR TITLE
Add centrs, bench-routeros-tools, and donny to site

### DIFF
--- a/repo-config.ts
+++ b/repo-config.ts
@@ -82,6 +82,10 @@ export const REPO_SYMBOLS: Record<string, string> = {
     // === Adventures (the "plants" 🌱) ===
     "adventure":          "\u2207",  // ∇ del/nabla — explore, descend into the unknown
     "wargames":           "\u2363",  // ⍣ power operator — shall we play a game?
+
+    // === TypeScript/Python Developer Libraries ===
+    "centrs":                "\u2355",  // ⍕ format — multi-protocol API surface
+    "bench-routeros-tools":  "\u2374",  // ⍴ rho/shape — measuring and comparing strategies
 };
 
 /** Fallback symbol for repos not in the mapping */
@@ -196,6 +200,17 @@ export const REPO_OVERRIDES: Record<string, RepoOverride> = {
     wargames: {
         category: "containers",
     },
+    centrs: {
+        category: "dev-tools",
+        tagline: "Multi-protocol RouterOS API library for TypeScript with built-in CLI",
+    },
+    "bench-routeros-tools": {
+        category: "dev-tools",
+        tagline: "Benchmark AI agent RouterOS support across MCPs, skills, and retrieval",
+        externalLinks: [
+            { label: "GitHub", url: "https://github.com/tikoci/bench-routeros-tools", style: "primary", description: "Benchmarks and results" },
+        ],
+    },
 };
 
 /** Graph edges between repos */
@@ -234,6 +249,14 @@ export const RELATIONSHIPS: Relationship[] = [
 
     // Network scripts family
     { source: "netserver", target: "netinstall", type: "topic" },
+
+    // TypeScript API layer
+    { source: "centrs", target: "rosetta", type: "ecosystem" },
+    { source: "centrs", target: "lsp-routeros-ts", type: "sibling" },
+
+    // AI benchmarking
+    { source: "bench-routeros-tools", target: "rosetta", type: "topic" },
+    { source: "bench-routeros-tools", target: "routeros-skills", type: "topic" },
 ];
 
 /** Repos to exclude even if they have stars */

--- a/src/dev-tools.html
+++ b/src/dev-tools.html
@@ -4,11 +4,11 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
-    <title>VSCode Extensions — TIKOCI</title>
-    <meta name="description" content="TIKOCI VSCode extensions for MikroTik RouterOS: RouterOS LSP language server and TikBook notebook toolkit — install directly from the VS Code Marketplace.">
+    <title>Developer Tools — TIKOCI</title>
+    <meta name="description" content="TIKOCI developer tools for MikroTik RouterOS: VS Code extensions, TypeScript API libraries, and AI benchmarking — open source tools for RouterOS developers.">
     <link rel="canonical" href="https://tikoci.github.io/dev-tools.html">
-    <meta property="og:title" content="VSCode Extensions — TIKOCI">
-    <meta property="og:description" content="TIKOCI VSCode extensions for MikroTik RouterOS: RouterOS LSP language server and TikBook notebook toolkit — install directly from the VS Code Marketplace.">
+    <meta property="og:title" content="Developer Tools — TIKOCI">
+    <meta property="og:description" content="TIKOCI developer tools for MikroTik RouterOS: VS Code extensions, TypeScript API libraries, and AI benchmarking — open source tools for RouterOS developers.">
     <meta property="og:url" content="https://tikoci.github.io/dev-tools.html">
     <meta property="og:type" content="website">
     <meta name="twitter:card" content="summary">
@@ -75,8 +75,10 @@
     </header>
 
     <main class="container">
-        <h1>VSCode Extensions</h1>
-        <p>Two purpose-built Visual Studio Code extensions for working with MikroTik RouterOS — syntax intelligence, a notebook interface, and a growing set of RouterOS-specific tools, all wired directly to a live router.</p>
+        <h1>Developer Tools</h1>
+        <p>Open source tools for working with MikroTik RouterOS — VS Code extensions for syntax intelligence and notebooks, TypeScript libraries for API access and automation, and benchmarking for AI agent strategies.</p>
+
+        <h2>VS Code Extensions</h2>
 
         <blockquote>
             <p><strong>If you write RouterOS scripts or work with RouterOS configuration from a computer, these extensions are worth trying.</strong> Install RouterOS LSP for syntax checking and completions in any <code>.rsc</code> file, then add TikBook for a full notebook and tooling experience. Both are free, open source, and on the VS Code Marketplace.</p>
@@ -223,6 +225,41 @@
             <p>Packages WinBox 4.0 as a <kbd>.deb</kbd> for Linux, with a desktop icon. Provided as a template for packaging WinBox on various Linux distributions, rather than for wide redistribution.</p>
             <footer>
                 <a href="https://github.com/tikoci/winbox-deb">GitHub</a>
+            </footer>
+        </article>
+
+        <h2>Libraries &amp; CLI Tools</h2>
+
+        <!-- centrs -->
+        <article>
+            <header>
+                <h2><a href="https://github.com/tikoci/centrs">centrs</a> <mark class="new">NEW</mark> <mark class="lang">TypeScript</mark></h2>
+            </header>
+            <p>Modern multi-protocol RouterOS API library for TypeScript. Provides a unified interface across RouterOS&rsquo;s multiple API protocols &mdash; REST, WebSocket, and the binary API &mdash; plus a ready-to-run CLI for scripting and automation without writing any setup code.</p>
+            <footer>
+                <a href="https://github.com/tikoci/centrs" target="_blank" rel="noopener">GitHub</a>
+            </footer>
+        </article>
+
+        <!-- donny -->
+        <article>
+            <header>
+                <h2><a href="https://github.com/tikoci/donny">donny</a> <mark class="lang">TypeScript</mark></h2>
+            </header>
+            <p>Experimental TypeScript library and CLI for <strong>MikroTik The Dude</strong> &mdash; the network monitoring and management application from MikroTik. Provides programmatic access to The Dude&rsquo;s SQLite database (<code>dude.db</code>) for reading device topology, monitoring history, and network maps.</p>
+            <footer>
+                <a href="https://github.com/tikoci/donny" target="_blank" rel="noopener">GitHub</a>
+            </footer>
+        </article>
+
+        <!-- bench-routeros-tools -->
+        <article>
+            <header>
+                <h2><a href="https://github.com/tikoci/bench-routeros-tools">bench-routeros-tools</a> <mark class="new">NEW</mark> <mark class="lang">Python</mark></h2>
+            </header>
+            <p>Benchmarks RouterOS AI agent-support strategies across MCPs, skills, and retrieval methods. Useful for comparing how well different AI tooling configurations handle RouterOS tasks, measuring quality and latency across approaches like <a href="https://github.com/tikoci/rosetta" target="_blank" rel="noopener">rosetta</a> MCP and <a href="https://github.com/tikoci/routeros-skills" target="_blank" rel="noopener">routeros-skills</a>.</p>
+            <footer>
+                <a href="https://github.com/tikoci/bench-routeros-tools" target="_blank" rel="noopener">GitHub</a>
             </footer>
         </article>
     </main>

--- a/src/index.html
+++ b/src/index.html
@@ -296,7 +296,15 @@
             </article>
             <article>
                 <h4><a href="https://github.com/tikoci/donny" target="_blank" rel="noopener">donny</a></h4>
-                <p>RouterOS automation and scripting tooling. See the <a href="https://github.com/tikoci/donny" target="_blank" rel="noopener">GitHub repo</a> for details.</p>
+                <p>TypeScript library and CLI for MikroTik The Dude &mdash; reads device topology, monitoring history, and network maps from The Dude&rsquo;s <code>dude.db</code> database.</p>
+            </article>
+            <article>
+                <h4><a href="https://github.com/tikoci/centrs" target="_blank" rel="noopener">centrs</a> <mark class="new">NEW</mark></h4>
+                <p>Multi-protocol RouterOS API library for TypeScript. Unified interface across REST, WebSocket, and the binary API, with a ready-to-run CLI.</p>
+            </article>
+            <article>
+                <h4><a href="https://github.com/tikoci/bench-routeros-tools" target="_blank" rel="noopener">bench-routeros-tools</a> <mark class="new">NEW</mark></h4>
+                <p>Benchmarks RouterOS AI agent-support strategies across MCPs, skills, and retrieval &mdash; for comparing how different AI tooling configurations handle RouterOS tasks.</p>
             </article>
             <article>
                 <h4><a href="https://github.com/tikoci/fat-chr" target="_blank" rel="noopener">fat-chr</a></h4>


### PR DESCRIPTION
Three newer tikoci repos were missing from the website build:

- centrs (TypeScript multi-protocol RouterOS API library) — new, not in
  repo-config.ts or any page
- bench-routeros-tools (Python AI agent benchmarking) — new, same
- donny — already in repo-config.ts and index.html but missing from dev-tools.html

Changes:
- repo-config.ts: add REPO_SYMBOLS (⍕ for centrs, ⍴ for bench-routeros-tools),
  REPO_OVERRIDES with category/tagline, and graph RELATIONSHIPS for both new repos
- src/dev-tools.html: broaden page from "VSCode Extensions" to "Developer Tools",
  add "Libraries & CLI Tools" section with cards for centrs, donny, and
  bench-routeros-tools
- src/index.html: fix vague donny description to reflect The Dude database use case,
  add centrs and bench-routeros-tools cards to Other Projects grid

https://claude.ai/code/session_012R3V8LrgWDqQFda68CVx9m

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new projects (`centrs` and `bench-routeros-tools`) to the developer tools catalog and project listings.
  * Introduced a new "Libraries & CLI Tools" section featuring TypeScript and Python development tools.

* **Updates**
  * Refreshed project descriptions and metadata for developer tools.
  * Updated page branding and Open Graph tags on the developer tools section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->